### PR TITLE
set correct version

### DIFF
--- a/.github/workflows/immunityunity.yml
+++ b/.github/workflows/immunityunity.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: '3.6.3'
           


### PR DESCRIPTION
`r-lib/actions/setup-r@master` was failing for me, too, on some of my projects. Changing it to `@v2` seemed to fix it.